### PR TITLE
Fix CancelPredictionRequest by adding missing $method POST parameter.

### DIFF
--- a/src/Requests/CancelPredictionRequest.php
+++ b/src/Requests/CancelPredictionRequest.php
@@ -7,7 +7,7 @@ use Saloon\Http\Request;
 
 class CancelPredictionRequest extends Request
 {
-    public Method $method = Method::GET;
+    public Method $method = Method::POST;
     
     public function __construct(
         protected string $id

--- a/src/Requests/CancelPredictionRequest.php
+++ b/src/Requests/CancelPredictionRequest.php
@@ -2,10 +2,13 @@
 
 namespace Sawirricardo\Replicate\Requests;
 
+use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
 class CancelPredictionRequest extends Request
 {
+    public Method $method = Method::GET;
+    
     public function __construct(
         protected string $id
     ) {


### PR DESCRIPTION
I was getting the "Typed property Saloon\Http\Request::$method must not be accessed before initialization" error when trying to cancel the prediction.